### PR TITLE
Fixed an NPE on the default package

### DIFF
--- a/src/main/scala/edu/illinois/wala/classLoader/M.scala
+++ b/src/main/scala/edu/illinois/wala/classLoader/M.scala
@@ -16,7 +16,10 @@ class RichM(val m: M) extends AnyVal {
   def name = m.getSelector().getName().toString()
 
   def prettyPrint: String = {
-    val packageName = m.getDeclaringClass().getName().getPackage().toString().replace('/', '.')
+    val packageName = m.getDeclaringClass().getName().getPackage() match {
+      case p: AnyRef => p.toString().replace('/', '.')
+      case null => ""
+    }
     packageName + "." + m.getDeclaringClass().name + "." + m.name
   }
 


### PR DESCRIPTION
The default package is represented in WALA by 'null', and this fix prevents an NPE for occuring when trying to get the name of a class in the default package.